### PR TITLE
Fix '$key is not defined' error

### DIFF
--- a/src/views/mount-component.blade.php
+++ b/src/views/mount-component.blade.php
@@ -1,4 +1,4 @@
-@if(is_null($key))
+@isset($key)
     @livewire($name, $params)    
 @else
     @livewire($name, $params, key($key))    

--- a/src/views/mount-component.blade.php
+++ b/src/views/mount-component.blade.php
@@ -1,4 +1,4 @@
-@isset($key)
+@if(!isset($key))
     @livewire($name, $params)    
 @else
     @livewire($name, $params, key($key))    


### PR DESCRIPTION
Please check this. 
If `$key` variable is not set - PHP will throw an error.
The better way to handle it - use `isset` instead of `is_null`.

